### PR TITLE
Fix erronous code for php 7.2

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -4,8 +4,8 @@
 
 
 
-	define_safe(MTF_NAME, 'Field: Multilingual Tag List');
-	define_safe(MTF_GROUP, 'multilingual_tag_field');
+	define_safe('MTF_NAME', 'Field: Multilingual Tag List');
+	define_safe('MTF_GROUP', 'multilingual_tag_field');
 
 
 


### PR DESCRIPTION
In php 7.2, use of inexistant constant gives an error instead of possibly being transformed to a string.